### PR TITLE
fix: typo in method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ class UserCreator
   def call
     @user.save!
   rescue ActiveRecord::RecordInvalid
-    merge_errors_from_record(@user)
+    merge_errors_from(@user)
   end
 end
 


### PR DESCRIPTION
Fix a typo in the README about the method name to merge record errors